### PR TITLE
adding default to gdownloader switch statement

### DIFF
--- a/StanfordCPPLib/graphics/gdownloader.cpp
+++ b/StanfordCPPLib/graphics/gdownloader.cpp
@@ -5,6 +5,8 @@
  * See the .h file for the declarations of each member and comments.
  *
  * @author Marty Stepp
+ * @version 2018/10/12
+ * - added default to switch to address warnings
  * @version 2018/09/23
  * - added macro checks to improve compatibility with old Qt versions
  * @version 2018/09/18
@@ -189,6 +191,7 @@ std::string GDownloader::qtNetworkErrorToString(QNetworkReply::NetworkError nerr
     case QNetworkReply::UnknownServerError: return "unknown server error";
     case QNetworkReply::NoError:
         break;
+    default: return "";
     }
     return "";
 }


### PR DESCRIPTION
When building the library for the homeworks, I keep seeing this error:

```bash
../lib/StanfordCPPLib/spl.cpp: In static member function ‘static std::__cxx11::string GDownloader::qtNetworkErrorToString(QNetworkReply::NetworkError)’:
../lib/StanfordCPPLib/spl.cpp:23028:12: warning: enumeration value ‘TooManyRedirectsError’ not handled in switch [-Wswitch]
     switch (nerror) {
            ^
../lib/StanfordCPPLib/spl.cpp:23028:12: warning: enumeration value ‘InsecureRedirectError’ not handled in switch [-Wswitch]
```

and the [stackoverflow wisdom](https://stackoverflow.com/questions/37254496/c-warning-enumeration-value-not-handled-in-switch-wswitch) suggests that it's a missing case, and that it's best to "be explicit." However when I look at the code where (I had expected) the cases of `InsecuredRedirectError` and `TooManyRedirectsError` to be missing, I [found them](https://github.com/stepp/stanford-cpp library/blob/master/StanfordCPPLib/graphics/gdownloader.cpp#L164-L167)!

```cpp
#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
    case QNetworkReply::TooManyRedirectsError: return "while following redirects, the maximum limit was reached. The limit is by default set to 50 or as set by QNetworkRequest::setMaxRedirectsAllowed(). (This value was introduced in 5.6.)";
    case QNetworkReply::InsecureRedirectError: return "while following redirects, the network access API detected a redirect from a encrypted protocol (https) to an unencrypted one (http). (This value was introduced in 5.6.)";
#endif // QT_VERSION
```

And actually it appears to be a conditional thing, something that is defined (or not) based on the version of QT. It generates a warning each time I compile the library (and maybe this is desired, something you want to not forget about and look more into later?). If not, I wanted to see if I could help with a proposed change. Specifically, given that when we get to the bottom of the switch (and no cases are triggered) we return an empty string:

```cpp
return "";
```

Why not add a default to the switch, essentially doing the same? It is somewhat  redundant to have a return "" twice, but in that in addresses a compile warning, maybe it's okay in this case? I don't think we could remove the return at the bottom because the function expects a string, and we would see a different warning. 

```cpp
.../lib/StanfordCPPLib/spl.cpp:23068:1: error: control reaches end of non-void function [-Werror=return-type]
```

I'm of course new to C++ so I might be missing something entirely, and please disregard and close if this is the case. 