### PR TITLE
Update GTextArea to emit CHANGE_EVENTs when the text changes.

### DIFF
--- a/StanfordCPPLib/graphics/gtextarea.cpp
+++ b/StanfordCPPLib/graphics/gtextarea.cpp
@@ -384,6 +384,16 @@ void _Internal_QTextEdit::handleTextChange() {
                     /* source */ _gtextarea);
         textChangeEvent.setActionCommand(_gtextarea->getActionCommand());
         _gtextarea->fireEvent(textChangeEvent);
+        
+        // BUGFIX: for backward compatibility, also fire a CHANGE_EVENT
+        // (emits only to the old-style waitForEvent function)
+        GEvent changeEvent(
+                    /* class  */ CHANGE_EVENT,
+                    /* type   */ STATE_CHANGED,
+                    /* name   */ "statechange",
+                    /* source */ _gtextarea);
+        changeEvent.setActionCommand(_gtextarea->getActionCommand());
+        _gtextarea->fireEvent(changeEvent);
     }
 }
 


### PR DESCRIPTION
When using the waitForEvent() event-handling system, text updates to the GTextArea don't currently trigger CHANGE_EVENTs the way that other interactors do. This fixes this by porting equivalent code from GTextField into GTextArea.