### PR TITLE
Fix iteration bug on empty Grids.

### DIFF
--- a/Library/collections/gridlocation.cpp
+++ b/Library/collections/gridlocation.cpp
@@ -114,7 +114,11 @@ GridLocationRange::GridLocationRangeIterator GridLocationRange::begin() const {
 }
 
 bool GridLocationRange::contains(const GridLocation& loc) const {
-    return _start <= loc && loc <= _end;
+    /* The location is in range if it's between the relevant
+     * rows and columns.
+     */
+    return _start.row <= loc.row && _start.col <= loc.col &&
+           _end.row   >= loc.row && _end.col   >= loc.col;
 }
 
 GridLocationRange::GridLocationRangeIterator GridLocationRange::end() const {
@@ -134,7 +138,10 @@ int GridLocationRange::endRow() const {
 }
 
 bool GridLocationRange::isEmpty() const {
-    return _start > _end;
+    /* The range is empty if either the start row or the
+     * start column exceeds the end row or end column.
+     */
+    return _start.row > _end.row || _start.col > _end.col;
 }
 
 bool GridLocationRange::isRowMajor() const {

--- a/Library/collections/gridlocation.h
+++ b/Library/collections/gridlocation.h
@@ -102,7 +102,10 @@ private:
     public:
         GridLocationRangeIterator(const GridLocationRange* glr, bool end)
                 : glr(glr) {
-            if (end) {
+            /* Need to check that the range isn't empty. If the range
+             * is empty, we need to be an end iterator.
+             */
+            if (end || glr->isEmpty()) {
                 loc.row = glr->endRow() + 1;
                 loc.col = glr->endCol() + 1;
             } else {

--- a/SPL-unit-tests/test-grid.cpp
+++ b/SPL-unit-tests/test-grid.cpp
@@ -51,11 +51,34 @@ PROVIDED_TEST("Grid, forEach") {
     grid.fill(42);
     grid[2][0] = 17;
     grid[3][1] = 0;
+
+    /* Version 1: Range-based for loop. */
     Queue<int> expected {42, 42, 42, 42, 17, 42, 42, 0};
     for (int n : grid) {
         int exp = expected.dequeue();
         EXPECT_EQUAL( exp, n);
     }
+
+    /* Make sure we snagged everything. */
+    EXPECT(expected.isEmpty());
+
+    /* Version 2: Explicit .locations() loop. */
+    expected = {42, 42, 42, 42, 17, 42, 42, 0};
+    Queue<GridLocation> locs = { {0, 0}, {0, 1}, {1, 0}, {1, 1}, {2, 0}, {2, 1}, {3, 0}, {3, 1} };
+    for (GridLocation loc: grid.locations()) {
+        EXPECT_EQUAL(loc, locs.dequeue());
+        EXPECT_EQUAL(grid[loc], expected.dequeue());
+    }
+    EXPECT(expected.isEmpty());
+
+    /* Version 3: .locations() loop in col-major order. */
+    expected = {42, 42, 17, 42, 42, 42, 42, 0};
+    locs = { {0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}, {2, 1}, {3, 1} };
+    for (GridLocation loc: grid.locations(false)) {
+        EXPECT_EQUAL(loc, locs.dequeue());
+        EXPECT_EQUAL(grid[loc], expected.dequeue());
+    }
+    EXPECT(expected.isEmpty());
 }
 
 PROVIDED_TEST("Grid, access corners") {
@@ -138,4 +161,67 @@ PROVIDED_TEST("Grid, randomElement") {
     for (const std::string& s : list) {
         EXPECT(counts[s] > 0);
     }
+}
+
+PROVIDED_TEST("Grid<T>, locations() works on an empty Grid.") {
+    Grid<int> empty;
+    GridLocationRange range;
+
+    /* 0 x 0 */
+    empty = Grid<int>(0, 0);
+    range = empty.locations();
+    EXPECT_EQUAL(std::distance(range.begin(), range.end()), 0);
+
+    /* 0 x N */
+    empty = Grid<int>(0, 137);
+    range = empty.locations();
+    EXPECT_EQUAL(std::distance(range.begin(), range.end()), 0);
+
+    /* N x 0 */
+    empty = Grid<int>(137, 0);
+    range = empty.locations();
+    EXPECT_EQUAL(std::distance(range.begin(), range.end()), 0);
+}
+
+PROVIDED_TEST("GridLocationRange, contains") {
+    GridLocationRange range(1, 1, 2, 2);
+    EXPECT(range.contains({1, 1}));
+    EXPECT(range.contains({1, 2}));
+    EXPECT(range.contains({2, 1}));
+    EXPECT(range.contains({2, 2}));
+
+    EXPECT(!range.contains({1, 0}));
+    EXPECT(!range.contains({1, 3}));
+    EXPECT(!range.contains({2, 0}));
+    EXPECT(!range.contains({2, 3}));
+    EXPECT(!range.contains({0, 1}));
+    EXPECT(!range.contains({0, 2}));
+    EXPECT(!range.contains({3, 1}));
+    EXPECT(!range.contains({3, 2}));
+    EXPECT(!range.contains({0, 0}));
+    EXPECT(!range.contains({0, 3}));
+    EXPECT(!range.contains({3, 0}));
+    EXPECT(!range.contains({3, 3}));
+
+    /* Now, try this with empty ranges. */
+    range = GridLocationRange(1, 1, 0, 1); // No rows
+    EXPECT(!range.contains({0, 0}));
+    EXPECT(!range.contains({0, 1}));
+    EXPECT(!range.contains({1, 0}));
+    EXPECT(!range.contains({1, 1}));
+    EXPECT(range.isEmpty());
+
+    range = GridLocationRange(1, 1, 1, 0); // No columns
+    EXPECT(!range.contains({0, 0}));
+    EXPECT(!range.contains({0, 1}));
+    EXPECT(!range.contains({1, 0}));
+    EXPECT(!range.contains({1, 1}));
+    EXPECT(range.isEmpty());
+
+    range = GridLocationRange(1, 1, 0, 0); // No rows, columns
+    EXPECT(!range.contains({0, 0}));
+    EXPECT(!range.contains({0, 1}));
+    EXPECT(!range.contains({1, 0}));
+    EXPECT(!range.contains({1, 1}));
+    EXPECT(range.isEmpty());
 }


### PR DESCRIPTION
This corrects #64, an error in `GridLocationRange` / `GridLocationRangeIterator` that allowed for iteration over an empty `Grid<T>` using the `Grid<T>::locations()` function. For example:

```c++
Grid<int> empty(0, 0);

/* This loop executes even though the grid is empty. */
for (GridLocation loc: empty.locations()) {
    /* Triggers an error() because loc is out of bounds. */
    empty[loc] = 137;
}
```