### PR TITLE
Better error messages when students use custom types in collections.

### DIFF
--- a/Library/collections/deque.h
+++ b/Library/collections/deque.h
@@ -222,6 +222,7 @@ void Deque<ValueType>::enqueueFront(const ValueType& value) {
 
 template <typename ValueType>
 bool Deque<ValueType>::equals(const Deque<ValueType>& deque2) const {
+    ASSERT_HAS_EQUALITY(ValueType);
     return _elements == deque2._elements;
 }
 

--- a/Library/collections/linkedlist.h
+++ b/Library/collections/linkedlist.h
@@ -539,32 +539,38 @@ LinkedList<ValueType>::operator +=(const ValueType& value) {
  */
 template <typename ValueType>
 bool LinkedList<ValueType>::operator ==(const LinkedList& list2) const {
+    ASSERT_HAS_EQUALITY(ValueType);
     return _elements == list2._elements;
 }
 
 template <typename ValueType>
 bool LinkedList<ValueType>::operator !=(const LinkedList& list2) const {
-    return _elements != list2._elements;
+    ASSERT_HAS_EQUALITY(ValueType);
+    return !(*this == list2);
 }
 
 template <typename ValueType>
 bool LinkedList<ValueType>::operator <(const LinkedList& list2) const {
+    ASSERT_IS_COMPARABLE(ValueType);
     return _elements < list2._elements;
 }
 
 template <typename ValueType>
 bool LinkedList<ValueType>::operator <=(const LinkedList& list2) const {
+    ASSERT_IS_COMPARABLE(ValueType);
     return _elements <= list2._elements;
 }
 
 template <typename ValueType>
 bool LinkedList<ValueType>::operator >(const LinkedList& list2) const {
+    ASSERT_IS_COMPARABLE(ValueType);
     return _elements > list2._elements;
 }
 
 template <typename ValueType>
 bool LinkedList<ValueType>::operator >=(const LinkedList& list2) const {
-    return this->_elements >= list2._elements;
+    ASSERT_IS_COMPARABLE(ValueType);
+    return _elements >= list2._elements;
 }
 
 template <typename ValueType>

--- a/Library/collections/priorityqueue.h
+++ b/Library/collections/priorityqueue.h
@@ -281,6 +281,8 @@ void PriorityQueue<ValueType>::enqueue(const ValueType& value, double priority) 
 
 template <typename ValueType>
 bool PriorityQueue<ValueType>::equals(const PriorityQueue<ValueType>& pq2) const {
+    ASSERT_HAS_EQUALITY(ValueType);
+
     // optimization: if literally same pq, stop
     if (this == &pq2) {
         return true;
@@ -294,7 +296,7 @@ bool PriorityQueue<ValueType>::equals(const PriorityQueue<ValueType>& pq2) const
         if (!floatingPointEqual(backup1.peekPriority(), backup2.peekPriority())) {
             return false;
         }
-        if (backup1.dequeue() != backup2.dequeue()) {
+        if (!(backup1.dequeue() == backup2.dequeue())) {
             return false;
         }
     }
@@ -366,6 +368,8 @@ bool PriorityQueue<ValueType>::operator !=(const PriorityQueue& pq2) const {
  */
 template <typename T>
 int hashCode(const PriorityQueue<T>& pq) {
+    ASSERT_IS_HASHABLE(T);
+
     // (slow, memory-inefficient) implementation: copy pq, dequeue all, and hash together
     PriorityQueue<T> backup = pq;
     int code = hashSeed();
@@ -380,6 +384,8 @@ int hashCode(const PriorityQueue<T>& pq) {
 template <typename ValueType>
 std::ostream& operator <<(std::ostream& os,
                           const PriorityQueue<ValueType>& pq) {
+    ASSERT_STREAM_INSERTABLE(ValueType);
+
     os << "{";
 
     // faster implementation: print in heap order

--- a/Library/collections/typeproperties.h
+++ b/Library/collections/typeproperties.h
@@ -1,0 +1,345 @@
+/*
+ * File: typeproperties.h
+ * -------------------
+ * Internal helper functions used to check whether various types
+ * have various properties
+ */
+#pragma once
+
+#include "hashcode.h"
+#include <type_traits>
+#include <iostream>
+
+/*
+ * Checks that various operations are defined, giving nice error messages if
+ * they aren't.
+ */
+#define ASSERT_IS_COMPARABLE(...) \
+    static_assert(::stanfordcpplib::collections::IsLessThanComparable<__VA_ARGS__>::value,\
+                  "Oops! You tried comparing two objects that aren't comparable. Click this error for more details.")
+    /*
+     * Hello students! If you got directed to this line of code in a compiler error,
+     * it probably means that you wrote code that requires comparing two objects
+     * with the < operator that aren't comparable. This could be from trying to use
+     * the < operator directory, from trying to sort a list of objects, from using
+     * your type as the key in a Map, or from storing your object in a Set. By
+     * default, objects in C++ aren't comparable by <, hence the error.
+     *
+     * There are two ways to fix this. The first option would simply be to not use
+     * the object in a way that requires the comparison.
+     *
+     * The second way to fix this is to explicitly define an operator< function for your custom
+     * type. Here's the syntax for doing that:
+     *
+     *     bool operator< (const YourCustomType& lhs, const YourCustomType& rhs) {
+     *         using namespace stanfordcpplib::collections;
+     *         return compareTo(lhs.data1, rhs.data1,
+     *                          lhs.data2, rhs.data2,
+     *                          ...
+     *                          lhs.dataN, rhs.dataN) == -1; // -1 signals less than
+     *     }
+     *
+     * where data1, data2, ... dataN are the data members of your type. For example, if you had
+     * a custom type
+     *
+     *     struct MyType {
+     *         int myInt;
+     *         string myString;
+     *     };
+     *
+     * you would define the function
+     *
+     *     bool operator< (const MyType& lhs, const MyType& rhs) {
+     *         using namespace stanfordcpplib::collections;
+     *         return compareTo(lhs.myInt,    rhs.myInt,
+     *                          lhs.myString, rhs.myString) == -1;
+     *     }
+     *
+     * Hope this helps!
+     */
+
+#define ASSERT_HAS_EQUALITY(...) \
+    static_assert(::stanfordcpplib::collections::IsEqualityComparable<__VA_ARGS__>::value, \
+                  "Oops! You tried comparing two objects that aren't comparable. Click this error for more details.")
+
+    /*
+     * Hello students! If you got directed to this line of code in a compiler error,
+     * it probably means that you wrote code that requires comparing two objects
+     * with the == operator that aren't comparable. This could be from trying to use
+     * the == operator directory, from using EXPECT_EQUAL or EXPECT_NOT_EQUAL on
+     * custom types, etc.
+     *
+     * There are two ways to fix this. The first option would simply be to not use
+     * the object in a way that requires the comparison.
+     *
+     * The second way to fix this is to explicitly define an operator< function for your custom
+     * type. Here's the syntax for doing that:
+     *
+     *     bool operator== (const YourCustomType& lhs, const YourCustomType& rhs) {
+     *         using namespace stanfordcpplib::collections;
+     *         return equalTo(lhs.data1, rhs.data1,
+     *                        lhs.data2, rhs.data2,
+     *                        ...
+     *                        lhs.dataN, rhs.dataN);
+     *     }
+     *
+     * where data1, data2, ... dataN are the data members of your type. For example, if you had
+     * a custom type
+     *
+     *     struct MyType {
+     *         int myInt;
+     *         string myString;
+     *     };
+     *
+     * you would define the function
+     *
+     *     bool operator== (const MyType& lhs, const MyType& rhs) {
+     *         using namespace stanfordcpplib::collections;
+     *         return equalTo(lhs.myInt,    rhs.myInt,
+     *                        lhs.myString, rhs.myString);
+     *     }
+     *
+     * Hope this helps!
+     */
+
+#define ASSERT_IS_HASHABLE(...) \
+    static_assert(::stanfordcpplib::collections::IsHashable<__VA_ARGS__>::value, \
+                  "Oops! You tried hashing an object that isn't hashable. Click this error for more details.")
+    /*
+     * Hello CS106 students! If you got directed to this line of code in a compiler error,
+     * it means your code needs to hash something that isn't hashable.
+     *
+     * In order to compute hash codes - either because you're storing a custom type in
+     * a HashMap or HashSet, or because you explicitly needed to compute a hash code -
+     * you need to define a hashCode() and operator== function for your custom type.
+     *
+     * There are two ways to fix this. The first option would simply be to not to do whatever
+     * operation requires hashing. This is probably the easiest option.
+     *
+     * The second way to fix this is to explicitly define a hashCode() and operator== function
+     * for your type. To do so, first define hashCode as follows:
+     *
+     *     int hashCode(const YourCustomType& obj) {
+     *         return hashCode(obj.data1, obj.data2, ..., obj.dataN);
+     *     }
+     *
+     * where data1, data2, ... dataN are the data members of your type. For example, if you had
+     * a custom type
+     *
+     *     struct MyType {
+     *         int myInt;
+     *         string myString;
+     *     };
+     *
+     * you would define the function
+     *
+     *     int hashCode(const MyType& obj) {
+     *         return hashCode(obj.myInt, obj.myString);
+     *     }
+     *
+     * Second, define operator== as follows:
+     *
+     *     bool operator== (const YourCustomType& lhs, const YourCustomType& rhs) {
+     *         using namespace stanfordcpplib::collections;
+     *         return equalTo(lhs.data1, rhs.data1,
+     *                        lhs.data2, rhs.data2,
+     *                        ...
+     *                        lhs.dataN, rhs.dataN);
+     *     }
+     *
+     * where data1, data2, ... dataN are the data members of your type. For example, if you had
+     * a custom type
+     *
+     *     struct MyType {
+     *         int myInt;
+     *         string myString;
+     *     };
+     *
+     * you would define the function
+     *
+     *     bool operator== (const MyType& lhs, const MyType& rhs) {
+     *         using namespace stanfordcpplib::collections;
+     *         return equalTo(lhs.myInt,    rhs.myInt,
+     *                        lhs.myString, rhs.myString);
+     *     }
+     *
+     * Hope this helps!
+     */
+
+#define ASSERT_STREAM_INSERTABLE(...) \
+    static_assert(::stanfordcpplib::collections::IsStreamInsertable<__VA_ARGS__>::value,\
+                  "Oops! You tried printing an object that isn't printable. Click this error for more details.")
+
+    /*
+     * Hello CS106 students! If you got directed to this line of code in a compiler error,
+     * it means your code needs to print something that isn't printable.
+     *
+     * In order to print a value to cout, or to use SimpleTest on a custom value, that
+     * value needs to have a function called operator<< defined for it. If this doesn't
+     * exist, then C++ will cause an error.
+     *
+     * There are two ways to fix this. The first option would simply be to not to do whatever
+     * operation requires printing the value. This is probably the easiest option.
+     *
+     * The second way to fix this is to explicitly define the operator<< function for your
+     * type. To do this, write a function that looks like this:
+     *
+     *     std::ostream& operator<< (std::ostream& out, const YourCustomType& obj) {
+     *         // ... write code here to print out the contents of your custom
+     *         // ... type. Instead of printing to cout, though, print to out.
+     *
+     *         return out;
+     *     }
+     *
+     * For example, if you had a custom type
+     *
+     *     struct MyType {
+     *         int myInt;
+     *         string myString;
+     *     };
+     *
+     * you might define the function
+     *
+     *     std::ostream& operator<< (std::ostream& out, const MyType& obj) {
+     *         out << "{" << obj.myInt << ", " << obj.myString << "}";
+     *         return out;
+     *     }
+     *
+     * Hope this helps!
+     */
+
+#define ASSERT_STREAM_EXTRACTABLE(...) \
+    static_assert(::stanfordcpplib::collections::IsStreamExtractable<__VA_ARGS__>::value,\
+                  "Oops! You tried reading an object that isn't readable. Click this error for more details.")
+    /*
+     * Hello CS106 students! If you got directed to this line of code in a compiler error,
+     * it means your code needs to read something that isn't readable.
+     *
+     * In order to print a value to cout, or to use SimpleTest on a custom value, that
+     * value needs to have a function called operator>> defined for it. If this doesn't
+     * exist, then C++ will cause an error.
+     *
+     * There are two ways to fix this. The first option would simply be to not to do whatever
+     * operation requires printing the value. This is probably the easiest option.
+     *
+     * The second way to fix this is to explicitly define the operator>> function for your
+     * type. To do this, write a function that looks like this:
+     *
+     *     std::istream& operator>> (std::istream& in, YourCustomType& obj) {
+     *         // ... write code here to read a YourCustomType. Instead of using
+     *         // ... cin here, though, use in.
+     *
+     *         return in;
+     *     }
+     *
+     * Hope this helps!
+     */
+
+namespace stanfordcpplib {
+    namespace collections {
+        /*
+         * The types below are used to check whether a type has various properties
+         * (comparable via <, hashable, comparable via ==, capable of being output
+         * to a stream, capable of being read from a stream, etc.
+         *
+         * This is used to provide better compiler diagnostics to students when
+         * they try to instantiate our types incorrectly.
+         *
+         * Later on, when C++20 concepts are rolled out, we should consider
+         * replacing this code with concepts.
+         */
+        template <typename T>
+        struct IsLessThanComparable {
+        private:
+            /* Use SFNIAE overloading to detect which of these two options to pick. */
+            struct Yes{};
+            struct No {};
+
+            template <typename U>
+            static Yes check(int,
+                             decltype(std::declval<U>() < std::declval<U>()) = false);
+            template <typename U> static No  check(...);
+
+        public:
+            static constexpr bool value =
+                    std::conditional<std::is_same<decltype(check<T>(0)), Yes>::value,
+            std::true_type,
+            std::false_type>::type::value;
+        };
+
+        template <typename T>
+        struct IsEqualityComparable {
+        private:
+            /* Use SFNIAE overloading to detect which of these two options to pick. */
+            struct Yes{};
+            struct No {};
+
+            template <typename U>
+            static Yes check(int,
+                             decltype(std::declval<U>() == std::declval<U>()) = false);
+            template <typename U> static No  check(...);
+
+        public:
+            static constexpr bool value =
+                    std::conditional<std::is_same<decltype(check<T>(0)), Yes>::value,
+            std::true_type,
+            std::false_type>::type::value;
+        };
+
+        template <typename T>
+        struct IsStreamInsertable {
+        private:
+            /* Use SFNIAE overloading to detect which of these two options to pick. */
+            struct Yes{};
+            struct No {};
+
+            template <typename U>
+            static Yes check(typename std::remove_reference<decltype(std::cout << std::declval<U>())>*);
+            template <typename U> static No  check(...);
+
+        public:
+            static constexpr bool value =
+                    std::conditional<std::is_same<decltype(check<T>(nullptr)), Yes>::value,
+            std::true_type,
+            std::false_type>::type::value;
+        };
+
+        template <typename T>
+        struct IsStreamExtractable {
+        private:
+            /* Use SFNIAE overloading to detect which of these two options to pick. */
+            struct Yes{};
+            struct No {};
+
+            template <typename U>
+            static Yes check(typename std::remove_reference<decltype(std::cin >> std::declval<U&>())>*);
+            template <typename U> static No  check(...);
+
+        public:
+            static constexpr bool value =
+                    std::conditional<std::is_same<decltype(check<T>(nullptr)), Yes>::value,
+            std::true_type,
+            std::false_type>::type::value;
+        };
+
+        template <typename T>
+        struct IsHashable {
+        private:
+            /* Use SFNIAE overloading to detect which of these two options to pick. */
+            struct Yes{};
+            struct No {};
+
+            template <typename U>
+            static Yes check(int,
+                             decltype(hashCode(std::declval<U>())) = 0,
+                             decltype(std::declval<U>() == std::declval<U>()) = false);
+            template <typename U> static No  check(...);
+
+        public:
+            static constexpr bool value =
+                    std::conditional<std::is_same<decltype(check<T>(0)), Yes>::value,
+            std::true_type,
+            std::false_type>::type::value;
+        };
+    }
+}

--- a/SPL-unit-tests/test-deque.cpp
+++ b/SPL-unit-tests/test-deque.cpp
@@ -86,3 +86,14 @@ PROVIDED_TEST("Deque, error on modify during iterate") {
    EXPECT_ERROR(removeDuring(deque));
 }
 
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    Deque<Bad> v1;
+    Deque<Bad> v2;
+    //(void) (v1 <  v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-grid.cpp
+++ b/SPL-unit-tests/test-grid.cpp
@@ -139,3 +139,14 @@ PROVIDED_TEST("Grid, randomElement") {
         EXPECT(counts[s] > 0);
     }
 }
+
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    Grid<Bad> v1;
+    Grid<Bad> v2;
+    //(void) (v1 <  v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-hashmap.cpp
+++ b/SPL-unit-tests/test-hashmap.cpp
@@ -167,3 +167,14 @@ PROVIDED_TEST("HashMap, streamExtract") {
     bool result = bool(hmstreambad >> hm);
     EXPECT(! result);
 }
+
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    HashMap<std::string, Bad> v1;
+    HashMap<std::string, Bad> v2;
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-linkedlist.cpp
+++ b/SPL-unit-tests/test-linkedlist.cpp
@@ -115,3 +115,15 @@ PROVIDED_TEST("LinkedList, sort") {
     LinkedList<int> exp { 0, 10, 10, 20, 30, 40, 50, 50, 60, 70, 90};
     EXPECT_EQUAL( exp.toString(), vec.toString());
 }
+
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    LinkedList<Bad> v1;
+    LinkedList<Bad> v2;
+    //(void) (v1 <  v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-map.cpp
+++ b/SPL-unit-tests/test-map.cpp
@@ -176,3 +176,15 @@ PROVIDED_TEST("Map, streamExtract") {
     stream >> map;
     EXPECT_EQUAL( "{1:10, 2:20, 3:30, 4:40}", map.toString());
 }
+
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    Map<std::string, Bad> v1;
+    Map<std::string, Bad> v2;
+    //(void) (v1 <  v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-pqueue.cpp
+++ b/SPL-unit-tests/test-pqueue.cpp
@@ -130,3 +130,14 @@ PROVIDED_TEST("PQueue, initializerList") {
         EXPECT_EQUAL( exp, act);
     }
 }
+
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    PriorityQueue<Bad> v1;
+    PriorityQueue<Bad> v2;
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-queue.cpp
+++ b/SPL-unit-tests/test-queue.cpp
@@ -95,3 +95,15 @@ PROVIDED_TEST("Queue, peekEnqueueBug") {
         EXPECT_EQUAL( "{10, 20, 30, 40, 50, 60, 70, 80, 90, 10}", queue.toString());
     }
 }
+
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    Queue<Bad> v1;
+    Queue<Bad> v2;
+    //(void) (v1 <  v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-set.cpp
+++ b/SPL-unit-tests/test-set.cpp
@@ -227,3 +227,17 @@ PROVIDED_TEST("Set, removeAndRetain") {
     all.intersect(primes);
      EXPECT_EQUAL(all, expected);
 }
+
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {
+        bool operator< (const Bad&) const {
+            return true;
+        }
+    };
+
+    Set<Bad> v1;
+    Set<Bad> v2;
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-stack.cpp
+++ b/SPL-unit-tests/test-stack.cpp
@@ -78,3 +78,14 @@ PROVIDED_TEST("Stack initializer_list") {
     EXPECT_EQUAL( "{10, 20, 30}", stack.toString());
 }
 
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    Stack<Bad> v1;
+    Stack<Bad> v2;
+    //(void) (v1 <  v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}

--- a/SPL-unit-tests/test-vector.cpp
+++ b/SPL-unit-tests/test-vector.cpp
@@ -335,3 +335,19 @@ PROVIDED_TEST("Vector sublist") {
         }
     }
 }
+
+/*
+ * Uncomment this code to test that we get sensible error messages for
+ * a lack of operator support on the underlying type.
+ */
+PROVIDED_TEST("Sensible compiler error messages.") {
+    struct Bad {};
+
+    Vector<Bad> v1;
+    Vector<Bad> v2;
+    //(void) (v1 <  v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (v1 == v2);        // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) hashCode(v1);      // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cout << v1); // Should trigger a static assertion rather than a long chain of sorrows
+    //(void) (std::cin  >> v1); // Should trigger a static assertion rather than a long chain of sorrows
+}


### PR DESCRIPTION
This edit introduces a bunch of extra `static_assert` checks that give cleaner error messages when students interact with our container types. For example, if you make a `Vector<T>` for a custom type `T` that isn't hashable, then calling `hashCode` on that vector gives a sensible error message about needing to define a hash code for the custom type. The same is true for relational operators, stream insertion, and stream extraction, and these assertions are there for all our containers, not just `Vector`.

This is essentially a fix for #65 but goes much beyond the `Vector` type.