### PR TITLE
Replace references to __FILE__ with actual file names in unit tests; …

### DIFF
--- a/SPL-unit-tests/test-filelib.cpp
+++ b/SPL-unit-tests/test-filelib.cpp
@@ -12,7 +12,9 @@ PROVIDED_TEST("Test filelib path utility functions") {
     EXPECT(fileExists(cwd));
     EXPECT(isDirectory(cwd));
     EXPECT(!isFile(cwd));
-    string thisFile = __FILE__;
+
+    /* 9/3/24: Can't use __FILE__ here as that resolves to ../../test-filelib.cpp. */
+    string thisFile = "test-filelib.cpp";
     EXPECT(fileExists(thisFile));
     EXPECT(isFile(thisFile));
     EXPECT(!isDirectory(thisFile));

--- a/SPL-unit-tests/test-simpio.cpp
+++ b/SPL-unit-tests/test-simpio.cpp
@@ -83,7 +83,11 @@ PROVIDED_TEST("getDoubleBetween rejects values outside range") {
 
 PROVIDED_TEST("promptUserForFile accepts valid filenames, rejects others") {
     ioutils::setConsoleEchoUserInput(true);
-    string input = stringJoin({"", "garbage", __FILE__, "", "/s", __FILE__}, '\n');
+
+    /* 9/3/24: __FILE__ will be ../../test-simpio.cpp, which will not load given the working
+     * directory. However, the explicit test-simpio.cpp will.
+     */
+    string input = stringJoin({"", "garbage", "test-simpio.cpp", "", "/s", "test-simpio.cpp"}, '\n');
     ioutils::redirectStdinBegin(input);
 
     EXPECT(fileExists(promptUserForFilename()));


### PR DESCRIPTION
The unit tests for `filelib` and `simpio` currently fail and infinitely loop (respectively) due to how `__FILE__` is resolved with the new build system. This change explicitly uses the filenames so that the tests run cleanly.