### PR TITLE
#81: Draw black pixels as black, not transparent.

### DIFF
--- a/Library/graphics/gcolor.cpp
+++ b/Library/graphics/gcolor.cpp
@@ -184,7 +184,7 @@ GColor::GColor() {
 
 /*static*/ int GColor::fixAlpha(int argb) {
     int alpha = ((argb & 0xff000000) >> 24) & 0x000000ff;
-    if (alpha == 0 && (argb & 0x00ffffff) != 0) {
+    if (alpha == 0) {
         argb = argb | 0xff000000;   // set full 255 alpha
     }
     return argb;

--- a/Library/graphics/gcolor.h
+++ b/Library/graphics/gcolor.h
@@ -164,8 +164,6 @@ public:
 
     /**
      * Sets the 'alpha' (high order bits) of the given integer to ff.
-     * If RGB is not completely black, but alpha is 0, assumes that the
-     * client meant to use an opaque color and add ff as alpha channel.
      */
     static int fixAlpha(int argb);
 

--- a/SPL-unit-tests/test-graphics.cpp
+++ b/SPL-unit-tests/test-graphics.cpp
@@ -155,7 +155,16 @@ MANUAL_TEST("GCanvas with image") {
     }
 
     img->setPixels(grid);
+    pause(500);
+
+    label->setText("setRGB to draw black pixels (slow; should be obviously black)");
+    for (int y = 0; y < img->getHeight()/2; y++) {
+        for (int x = 0; x < img->getWidth()/2; x++) {
+            img->setRGB(x + img->getWidth()/4, y + img->getHeight()/4, 0x000000);
+        }
+    }
     pause(1000);
+
     gw->setCloseOperation(GWindow::CLOSE_DISPOSE);
     label->setText("Done, close window to exit this test");
     while (gw->isVisible()) {}


### PR DESCRIPTION
Fixes #81 by always setting alpha of all pixels, including black, to 0xFF.