### PR TITLE
Change const overload of `Map::operator[]` and `HashMap::operator[]` to return references, not copies

### DIFF
--- a/Library/collections/hashmap.h
+++ b/Library/collections/hashmap.h
@@ -254,7 +254,7 @@ public:
      * whose value is set to the default for the value type.
      */
     ValueType& operator [](const KeyType& key);
-    ValueType operator [](const KeyType& key) const;
+    const ValueType& operator [](const KeyType& key) const;
 
     /*
      * Operator: +
@@ -579,8 +579,19 @@ ValueType& HashMap<KeyType, ValueType>::operator [](const KeyType& key) {
 }
 
 template <typename KeyType, typename ValueType>
-ValueType HashMap<KeyType, ValueType>::operator [](const KeyType& key) const {
-    return get(key);
+const ValueType& HashMap<KeyType, ValueType>::operator [](const KeyType& key) const {
+    auto itr = _elements.find(key);
+    if (itr != _elements.end()) {
+        return itr->second;
+    }
+    /* We need to return a reference to a default-constructed object of the
+     * specified type. We thus construct a unique default-initialized version
+     * of the object and return it.
+     */
+    else {
+        static const ValueType singleton{};
+        return singleton;
+    }
 }
 
 template <typename KeyType, typename ValueType>

--- a/Library/collections/map.h
+++ b/Library/collections/map.h
@@ -257,7 +257,7 @@ public:
      * whose value is set to the default for the value type.
      */
     ValueType& operator [](const KeyType& key);
-    const ValueType operator [](const KeyType& key) const;
+    const ValueType& operator [](const KeyType& key) const;
 
     /*
      * Operator: ==
@@ -553,8 +553,19 @@ ValueType& Map<KeyType, ValueType>::operator [](const KeyType& key) {
 }
 
 template <typename KeyType, typename ValueType>
-const ValueType Map<KeyType, ValueType>::operator [](const KeyType& key) const {
-    return get(key);
+const ValueType& Map<KeyType, ValueType>::operator [](const KeyType& key) const {
+    auto itr = _elements.find(key);
+    if (itr != _elements.end()) {
+        return itr->second;
+    }
+    /* We need to return a reference to a default-constructed object of the
+     * specified type. We thus construct a unique default-initialized version
+     * of the object and return it.
+     */
+    else {
+        static const ValueType singleton{};
+        return singleton;
+    }
 }
 
 template <typename KeyType, typename ValueType>

--- a/SPL-unit-tests/test-hashmap.cpp
+++ b/SPL-unit-tests/test-hashmap.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <memory>
 
 
 /*
@@ -163,4 +164,39 @@ PROVIDED_TEST("HashMap, streamExtract") {
     std::istringstream hmstreambad("1:1, 2, 33}");
     bool result = bool(hmstreambad >> hm);
     EXPECT(! result);
+}
+
+PROVIDED_TEST("HashMap, operator[]") {
+    const HashMap<std::string, bool> m1 = {
+        { "A", true }
+    };
+    const HashMap<std::string, int> m2 = {
+        { "A", 1 }
+    };
+    const HashMap<std::string, float> m3 = {
+        { "A", 1.0f }
+    };
+    const HashMap<std::string, double> m4 = {
+        { "A", 1.0 }
+    };
+
+    auto ptr = std::make_shared<std::istringstream>();
+    const HashMap<std::string, std::shared_ptr<std::istringstream>> m5 = {
+        { "A", ptr }
+    };
+
+    EXPECT_EQUAL(m1["A"], true);
+    EXPECT_EQUAL(m1["B"], false);
+
+    EXPECT_EQUAL(m2["A"], 1);
+    EXPECT_EQUAL(m2["B"], 0);
+
+    EXPECT_EQUAL(m3["A"], 1.0f);
+    EXPECT_EQUAL(m3["B"], 0.0f);
+
+    EXPECT_EQUAL(m4["A"], 1.0);
+    EXPECT_EQUAL(m4["B"], 0.0);
+
+    EXPECT_EQUAL(m5["A"], ptr);
+    EXPECT_EQUAL(m5["B"], nullptr);
 }

--- a/SPL-unit-tests/test-map.cpp
+++ b/SPL-unit-tests/test-map.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <memory>
 
 
 
@@ -172,4 +173,39 @@ PROVIDED_TEST("Map, streamExtract") {
     Map<int, int> map;
     stream >> map;
     EXPECT_EQUAL(map.toString(), "{1:10, 2:20, 3:30, 4:40}");
+}
+
+PROVIDED_TEST("Map, operator[]") {
+    const Map<std::string, bool> m1 = {
+        { "A", true }
+    };
+    const Map<std::string, int> m2 = {
+        { "A", 1 }
+    };
+    const Map<std::string, float> m3 = {
+        { "A", 1.0f }
+    };
+    const Map<std::string, double> m4 = {
+        { "A", 1.0 }
+    };
+
+    auto ptr = std::make_shared<std::istringstream>();
+    const Map<std::string, std::shared_ptr<std::istringstream>> m5 = {
+        { "A", ptr }
+    };
+
+    EXPECT_EQUAL(m1["A"], true);
+    EXPECT_EQUAL(m1["B"], false);
+
+    EXPECT_EQUAL(m2["A"], 1);
+    EXPECT_EQUAL(m2["B"], 0);
+
+    EXPECT_EQUAL(m3["A"], 1.0f);
+    EXPECT_EQUAL(m3["B"], 0.0f);
+
+    EXPECT_EQUAL(m4["A"], 1.0);
+    EXPECT_EQUAL(m4["B"], 0.0);
+
+    EXPECT_EQUAL(m5["A"], ptr);
+    EXPECT_EQUAL(m5["B"], nullptr);
 }


### PR DESCRIPTION
This addresses issue #74. At present, using the const overload of `operator[]` on `Map` or `HashMap` returns a copy of the associated value, which can lead to performance degradation when marking function parameters `const`.

This PR changes those functions to return `const ValueType&`'s. In the event that the value is not present in the map, a `static` local variable that is default initialized is returned instead.